### PR TITLE
Fixes

### DIFF
--- a/contracts/Factory.vy
+++ b/contracts/Factory.vy
@@ -87,8 +87,7 @@ def payment_received(_token: address, _amount: uint256) -> bool:
 
 @external
 def create_payment_address(_account: address = msg.sender):
-    assert self.account_to_payment_address[_account] == empty(address)
-    sweeper: address = create_copy_of(PROXY_IMPLEMENTATION)
+    sweeper: address = create_copy_of(PROXY_IMPLEMENTATION, salt=convert(_account, bytes32))
     self.account_to_payment_address[_account] = sweeper
     self.payment_address_to_account[sweeper] = _account
 

--- a/contracts/Sweeper.vy
+++ b/contracts/Sweeper.vy
@@ -9,6 +9,12 @@ interface Factory:
     def receiver() -> address: view
 
 
+event TokenBalanceRecovered:
+    receiver: address
+    token: address
+    amount: uint256
+
+
 FACTORY: public(immutable(Factory))
 
 
@@ -41,3 +47,5 @@ def recover_token_balance(_token: ERC20):
     assert msg.sender == FACTORY.payment_address_to_account(self) or msg.sender == FACTORY.owner()
     amount: uint256 = _token.balanceOf(self)
     _token.transfer(msg.sender, amount)
+
+    log TokenBalanceRecovered(msg.sender, _token.address, amount)


### PR DESCRIPTION
Use `CREATE2` for deterministic sweeper addresses - closes #6 
Add event for recovering tokens - closes #11 